### PR TITLE
Add Status method to Conn interface

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -50,6 +50,9 @@ type Conn interface {
 
 	// Close
 	Close() error
+
+	// Status returns the status of the underlying NATS conn.
+	Status() nats.Status
 }
 
 // Errors
@@ -269,6 +272,14 @@ func (sc *conn) Close() error {
 		return errors.New(cr.Error)
 	}
 	return nil
+}
+
+// Status returns the status of the underlying NATS conn.
+func (sc *conn) Status() nats.Status {
+	if sc.nc == nil {
+		return nats.CLOSED
+	}
+	return sc.nc.Status()
 }
 
 // Process a heartbeat from the NATS Streaming cluster

--- a/stan_test.go
+++ b/stan_test.go
@@ -1853,3 +1853,19 @@ func TestRaceAckOnClose(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	sc.Close()
 }
+
+func TestStatus(t *testing.T) {
+	s := RunServer(clusterName)
+	defer s.Shutdown()
+
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	if sc.Status() != nats.CONNECTED {
+		t.Fatal("Should have status set to CONNECTED")
+	}
+	sc.Close()
+	if sc.Status() != nats.CLOSED {
+		t.Fatal("Should have status set to CLOSED")
+	}
+}


### PR DESCRIPTION
Expose the underlying NATS conn status. Addresses #67.