### PR TITLE
[ADDED] Option setter for the URL client connects to

### DIFF
--- a/examples/stan-pub.go
+++ b/examples/stan-pub.go
@@ -31,14 +31,13 @@ func usage() {
 }
 
 func main() {
-	opts := stan.DefaultOptions
-
 	var clusterID string
 	var clientID string
 	var async bool
+	URL := stan.DefaultNatsURL
 
-	flag.StringVar(&opts.NatsURL, "s", stan.DefaultNatsURL, "The nats server URLs (separated by comma)")
-	flag.StringVar(&opts.NatsURL, "server", stan.DefaultNatsURL, "The nats server URLs (separated by comma)")
+	flag.StringVar(&URL, "s", stan.DefaultNatsURL, "The nats server URLs (separated by comma)")
+	flag.StringVar(&URL, "server", stan.DefaultNatsURL, "The nats server URLs (separated by comma)")
 	flag.StringVar(&clusterID, "c", "test-cluster", "The NATS Streaming cluster ID")
 	flag.StringVar(&clusterID, "cluster", "test-cluster", "The NATS Streaming cluster ID")
 	flag.StringVar(&clientID, "id", "stan-pub", "The NATS Streaming client ID to connect with")
@@ -56,9 +55,9 @@ func main() {
 		usage()
 	}
 
-	sc, err := stan.Connect(clusterID, clientID)
+	sc, err := stan.Connect(clusterID, clientID, stan.NatsURL(URL))
 	if err != nil {
-		log.Fatalf("Can't connect: %v.\nMake sure a NATS Streaming Server is running at: %s", err, opts.NatsURL)
+		log.Fatalf("Can't connect: %v.\nMake sure a NATS Streaming Server is running at: %s", err, URL)
 	}
 	defer sc.Close()
 

--- a/examples/stan-pub.go
+++ b/examples/stan-pub.go
@@ -34,7 +34,7 @@ func main() {
 	var clusterID string
 	var clientID string
 	var async bool
-	URL := stan.DefaultNatsURL
+	var URL string
 
 	flag.StringVar(&URL, "s", stan.DefaultNatsURL, "The nats server URLs (separated by comma)")
 	flag.StringVar(&URL, "server", stan.DefaultNatsURL, "The nats server URLs (separated by comma)")

--- a/examples/stan-sub.go
+++ b/examples/stan-sub.go
@@ -54,8 +54,7 @@ func main() {
 	var durable string
 	var qgroup string
 	var unsubscribe bool
-
-	URL := DefaultNatsURL
+	var URL string
 
 	//	defaultID := fmt.Sprintf("client.%s", nuid.Next())
 

--- a/examples/stan-sub.go
+++ b/examples/stan-sub.go
@@ -44,8 +44,6 @@ func printMsg(m *Msg, i int) {
 }
 
 func main() {
-	opts := DefaultOptions
-
 	var clusterID string
 	var clientID string
 	var showTime bool
@@ -57,10 +55,12 @@ func main() {
 	var qgroup string
 	var unsubscribe bool
 
+	URL := DefaultNatsURL
+
 	//	defaultID := fmt.Sprintf("client.%s", nuid.Next())
 
-	flag.StringVar(&opts.NatsURL, "s", DefaultNatsURL, "The nats server URLs (separated by comma)")
-	flag.StringVar(&opts.NatsURL, "server", DefaultNatsURL, "The nats server URLs (separated by comma)")
+	flag.StringVar(&URL, "s", DefaultNatsURL, "The nats server URLs (separated by comma)")
+	flag.StringVar(&URL, "server", DefaultNatsURL, "The nats server URLs (separated by comma)")
 	flag.StringVar(&clusterID, "c", "test-cluster", "The NATS Streaming cluster ID")
 	flag.StringVar(&clusterID, "cluster", "test-cluster", "The NATS Streaming cluster ID")
 	flag.StringVar(&clientID, "id", "", "The NATS Streaming client ID to connect with")
@@ -90,12 +90,11 @@ func main() {
 		usage()
 	}
 
-
-	sc, err := Connect(clusterID, clientID)
+	sc, err := Connect(clusterID, clientID, NatsURL(URL))
 	if err != nil {
-		log.Fatalf("Can't connect: %v.\nMake sure a NATS Streaming Server is running at: %s", err, opts.NatsURL)
+		log.Fatalf("Can't connect: %v.\nMake sure a NATS Streaming Server is running at: %s", err, URL)
 	}
-	log.Printf("Connected to %s clusterID: [%s] clientID: [%s]\n", opts.NatsURL, clusterID, clientID)
+	log.Printf("Connected to %s clusterID: [%s] clientID: [%s]\n", URL, clusterID, clientID)
 
 	subj, i := args[0], 0
 

--- a/stan.go
+++ b/stan.go
@@ -97,6 +97,14 @@ var DefaultOptions = Options{
 // Option is a function on the options for a connection.
 type Option func(*Options) error
 
+// NatsURL is an Option to set the URL the client should connect to.
+func NatsURL(u string) Option {
+	return func(o *Options) error {
+		o.NatsURL = u
+		return nil
+	}
+}
+
 // ConnectWait is an Option to set the timeout for establishing a connection.
 func ConnectWait(t time.Duration) Option {
 	return func(o *Options) error {

--- a/stan_test.go
+++ b/stan_test.go
@@ -1928,3 +1928,14 @@ func TestMaxPubAcksInflight(t *testing.T) {
 		t.Fatal("Should have blocked after 1 message sent")
 	}
 }
+
+func TestNatsURLOption(t *testing.T) {
+	s := RunServer(clusterName)
+	defer s.Shutdown()
+
+	sc, err := Connect(clusterName, clientName, NatsURL("nats://localhost:5555"))
+	if err == nil {
+		sc.Close()
+		t.Fatal("Expected connect to fail")
+	}
+}


### PR DESCRIPTION
Also fixed the pub and sub example to use this option setter. They
would otherwise only be able to connect to localhost:4222.

Resolves #94