### PR TITLE
Relax QueueSubscribe test with DurableName option

### DIFF
--- a/stan_test.go
+++ b/stan_test.go
@@ -268,12 +268,6 @@ func TestBasicQueueSubscription(t *testing.T) {
 		t.Fatalf("Expected no error on Subscribe, got %v\n", err)
 	}
 	defer sub.Unsubscribe()
-
-	// Test that we can not set durable status on queue subscribers.
-	_, err = sc.QueueSubscribe("foo", "bar", func(m *Msg) {}, DurableName("durable-queue-sub"))
-	if err == nil {
-		t.Fatalf("Expected non-nil error on QueueSubscribe with DurableName")
-	}
 }
 
 func TestBasicPubSub(t *testing.T) {


### PR DESCRIPTION
We plan to support durable queue subscribers. Removing the
part of test that expects failure so that this repo test harness
does not fail if server's master repo is changed.