### PR TITLE
Avoid fmt.Sprintf for simple subjects

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -193,7 +193,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	}
 
 	// Send Request to discover the cluster
-	discoverSubject := fmt.Sprintf("%s.%s", c.opts.DiscoverPrefix, stanClusterID)
+	discoverSubject := c.opts.DiscoverPrefix + "." + stanClusterID
 	req := &pb.ConnectRequest{ClientID: clientID, HeartbeatInbox: hbInbox}
 	b, _ := req.Marshal()
 	reply, err := c.nc.Request(discoverSubject, b, c.opts.ConnectTimeout)
@@ -223,7 +223,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	c.closeRequests = cr.CloseRequests
 
 	// Setup the ACK subscription
-	c.ackSubject = fmt.Sprintf("%s.%s", DefaultACKPrefix, nuid.Next())
+	c.ackSubject = DefaultACKPrefix + "." + nuid.Next()
 	if c.ackSubscription, err = c.nc.Subscribe(c.ackSubject, c.processAck); err != nil {
 		c.Close()
 		return nil, err
@@ -359,7 +359,7 @@ func (sc *conn) publishAsync(subject string, data []byte, ah AckHandler, ch chan
 		return "", ErrConnectionClosed
 	}
 
-	subj := fmt.Sprintf("%s.%s", sc.pubPrefix, subject)
+	subj := sc.pubPrefix + "." + subject
 	// This is only what we need from PubMsg in the timer below,
 	// so do this so that pe doesn't escape (and we same on new object)
 	peGUID := nuid.Next()


### PR DESCRIPTION
Saw one of these in ~~my dreams~~ a memory profile. For simple cases like "%s.%s" where both arguments are already passed as strings using the + operator avoids an allocation (at least most of the time. I think there is a limit based on the string size after which an allocation is needed) and some overhead from Sprintf itself.

Benchmark results:

```
name                old time/op    new time/op    delta
Publish-8             63.3µs ± 1%    60.3µs ± 1%   -4.69%          (p=0.008 n=5+5)
PublishAsync-8        3.03µs ± 2%    2.70µs ± 2%  -10.90%          (p=0.008 n=5+5)
Subscribe-8           2.00µs ± 2%    2.01µs ± 2%     ~             (p=0.452 n=5+5)
QueueSubscribe-8      2.45µs ± 1%    2.48µs ± 4%     ~             (p=0.310 n=5+5)
PublishSubscribe-8    4.72µs ± 3%    4.52µs ± 2%   -4.12%          (p=0.016 n=5+5)
TimeNow-8             20.3ns ± 1%    20.3ns ± 1%     ~             (p=0.603 n=5+5)

name                old alloc/op   new alloc/op   delta
Publish-8             1.32kB ± 0%    1.29kB ± 0%   -2.49%          (p=0.000 n=5+4)
PublishAsync-8        1.43kB ± 0%    1.39kB ± 0%   -2.61%          (p=0.000 n=5+4)
Subscribe-8             636B ± 0%      636B ± 0%     ~             (p=1.000 n=5+4)
QueueSubscribe-8        629B ± 0%      630B ± 0%     ~             (p=0.484 n=5+5)
PublishSubscribe-8    2.09kB ± 0%    2.03kB ± 0%   -2.46%          (p=0.008 n=5+5)
TimeNow-8             0.00B ±NaN%    0.00B ±NaN%     ~     (all samples are equal)

name                old allocs/op  new allocs/op  delta
Publish-8               28.0 ± 0%      26.0 ± 0%   -7.14%          (p=0.008 n=5+5)
PublishAsync-8          25.0 ± 0%      23.0 ± 0%   -8.00%          (p=0.008 n=5+5)
Subscribe-8             12.0 ± 0%      12.0 ± 0%     ~     (all samples are equal)
QueueSubscribe-8        12.0 ± 0%      12.0 ± 0%     ~     (all samples are equal)
PublishSubscribe-8      38.0 ± 0%      36.0 ± 0%   -5.26%          (p=0.008 n=5+5)
TimeNow-8              0.00 ±NaN%     0.00 ±NaN%     ~     (all samples are equal)
```

Testet with go version: commit f69991c