### PR TITLE
Bail if custom NATS conn is disconnected when connecting to Streaming

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -183,7 +183,11 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 		}
 		c.nc = nc
 		c.ncOwned = true
+	} else if !c.nc.IsConnected() {
+		// Bail if the custom NATS connection is disconnected
+		return nil, ErrBadConnection
 	}
+
 	// Create a heartbeat inbox
 	hbInbox := nats.NewInbox()
 	var err error


### PR DESCRIPTION
Currently it is possible to customize a raw NATS connection though if is not connected already then client panics when attempting to connect to the Streaming server.

```go
package main

import (
	"fmt"

	"github.com/nats-io/go-nats-streaming"
	"github.com/nats-io/nats"
)

func main() {
	opts := nats.DefaultOptions
	nc := nats.Conn{Opts: opts}
	_, err := stan.Connect("test-cluster", "client-123", stan.NatsConn(&nc))
	fmt.Printf("ERROR: %s\n", err)
       // ERROR: stan: invalid connection
}
```

Before:
```
STDERR: 

panic: assignment to entry in nil map

goroutine 1 [running]:
panic(0x25be60, 0xc42000d010)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/nats-io/nats.(*Conn).subscribe(0xc420095680, 0xc420010f20, 0x1d, 0x0, 0x0, 0xc42000d000, 0x0, 0x0, 0x0, 0x0)
	/Users/wally/repos/nats-dev/streaming/src/github.com/nats-io/nats/nats.go:1939 +0x28d
github.com/nats-io/nats.(*Conn).Subscribe(0xc420095680, 0xc420010f20, 0x1d, 0xc42000d000, 0x3e9a50, 0xc420016ba0, 0xc4200134d0)
	/Users/wally/repos/nats-dev/streaming/src/github.com/nats-io/nats/nats.go:1849 +0x68
github.com/nats-io/go-nats-streaming.Connect(0x2a31e4, 0xc, 0x2a28cc, 0xa, 0xc42004ba00, 0x1, 0x1, 0x0, 0x1000, 0x7, ...)
	/Users/wally/repos/nats-dev/streaming/src/github.com/nats-io/go-nats-streaming/stan.go:194 +0x25c
main.main()
	/var/folders/71/yz0v2km97nj130xcwk4xmqnw0000gn/T/babel-44564Kwl/go-src-44564fnW.go:16 +0x136
exit status 2
```
