### PR TITLE
Expose some nats subscription methods in streaming

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -266,12 +266,24 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 
 // ClearMaxPending resets the maximums seen so far.
 func (sub *subscription) ClearMaxPending() error {
-	return sub.inboxSub.ClearMaxPending()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return ErrBadSubscription
+	}
+	return inbox.ClearMaxPending()
 }
 
 // Delivered returns the number of delivered messages for this subscription.
 func (sub *subscription) Delivered() (int64, error) {
-	return sub.inboxSub.Delivered()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return -1, ErrBadSubscription
+	}
+	return inbox.Delivered()
 }
 
 // Dropped returns the number of known dropped messages for this subscription.
@@ -279,37 +291,73 @@ func (sub *subscription) Delivered() (int64, error) {
 // the server declares the connection a SlowConsumer, this number may not be
 // valid.
 func (sub *subscription) Dropped() (int, error) {
-	return sub.inboxSub.Dropped()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return -1, ErrBadSubscription
+	}
+	return inbox.Dropped()
 }
 
 // IsValid returns a boolean indicating whether the subscription
 // is still active. This will return false if the subscription has
 // already been closed.
 func (sub *subscription) IsValid() bool {
-	return sub.inboxSub.IsValid()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return false
+	}
+	return inbox.IsValid()
 }
 
 // MaxPending returns the maximum number of queued messages and queued bytes seen so far.
 func (sub *subscription) MaxPending() (int, int, error) {
-	return sub.inboxSub.MaxPending()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return -1, -1, ErrBadSubscription
+	}
+	return inbox.MaxPending()
 }
 
 // Pending returns the number of queued messages and queued bytes in the client for this subscription.
 func (sub *subscription) Pending() (int, int, error) {
-	return sub.inboxSub.Pending()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return -1, -1, ErrBadSubscription
+	}
+	return inbox.Pending()
 }
 
 // PendingLimits returns the current limits for this subscription.
 // If no error is returned, a negative value indicates that the
 // given metric is not limited.
 func (sub *subscription) PendingLimits() (int, int, error) {
-	return sub.inboxSub.PendingLimits()
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return -1, -1, ErrBadSubscription
+	}
+	return inbox.PendingLimits()
 }
 
 // SetPendingLimits sets the limits for pending msgs and bytes for this subscription.
 // Zero is not allowed. Any negative value means that the given metric is not limited.
 func (sub *subscription) SetPendingLimits(msgLimit, bytesLimit int) error {
-	return sub.inboxSub.SetPendingLimits(msgLimit, bytesLimit)
+	sub.Lock()
+	defer sub.Unlock()
+	inbox := sub.inboxSub
+	if inbox == nil {
+		return ErrBadSubscription
+	}
+	return inbox.SetPendingLimits(msgLimit, bytesLimit)
 }
 
 // closeOrUnsubscribe performs either close or unsubsribe based on

--- a/sub.go
+++ b/sub.go
@@ -268,22 +268,20 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 func (sub *subscription) ClearMaxPending() error {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return ErrBadSubscription
 	}
-	return inbox.ClearMaxPending()
+	return sub.inboxSub.ClearMaxPending()
 }
 
 // Delivered returns the number of delivered messages for this subscription.
 func (sub *subscription) Delivered() (int64, error) {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return -1, ErrBadSubscription
 	}
-	return inbox.Delivered()
+	return sub.inboxSub.Delivered()
 }
 
 // Dropped returns the number of known dropped messages for this subscription.
@@ -293,11 +291,10 @@ func (sub *subscription) Delivered() (int64, error) {
 func (sub *subscription) Dropped() (int, error) {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return -1, ErrBadSubscription
 	}
-	return inbox.Dropped()
+	return sub.inboxSub.Dropped()
 }
 
 // IsValid returns a boolean indicating whether the subscription
@@ -306,33 +303,30 @@ func (sub *subscription) Dropped() (int, error) {
 func (sub *subscription) IsValid() bool {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return false
 	}
-	return inbox.IsValid()
+	return sub.inboxSub.IsValid()
 }
 
 // MaxPending returns the maximum number of queued messages and queued bytes seen so far.
 func (sub *subscription) MaxPending() (int, int, error) {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return -1, -1, ErrBadSubscription
 	}
-	return inbox.MaxPending()
+	return sub.inboxSub.MaxPending()
 }
 
 // Pending returns the number of queued messages and queued bytes in the client for this subscription.
 func (sub *subscription) Pending() (int, int, error) {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return -1, -1, ErrBadSubscription
 	}
-	return inbox.Pending()
+	return sub.inboxSub.Pending()
 }
 
 // PendingLimits returns the current limits for this subscription.
@@ -341,11 +335,10 @@ func (sub *subscription) Pending() (int, int, error) {
 func (sub *subscription) PendingLimits() (int, int, error) {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return -1, -1, ErrBadSubscription
 	}
-	return inbox.PendingLimits()
+	return sub.inboxSub.PendingLimits()
 }
 
 // SetPendingLimits sets the limits for pending msgs and bytes for this subscription.
@@ -353,11 +346,10 @@ func (sub *subscription) PendingLimits() (int, int, error) {
 func (sub *subscription) SetPendingLimits(msgLimit, bytesLimit int) error {
 	sub.Lock()
 	defer sub.Unlock()
-	inbox := sub.inboxSub
-	if inbox == nil {
+	if sub.inboxSub == nil {
 		return ErrBadSubscription
 	}
-	return inbox.SetPendingLimits(msgLimit, bytesLimit)
+	return sub.inboxSub.SetPendingLimits(msgLimit, bytesLimit)
 }
 
 // closeOrUnsubscribe performs either close or unsubsribe based on

--- a/sub.go
+++ b/sub.go
@@ -30,6 +30,7 @@ type Msg struct {
 // Subscription represents a subscription within the NATS Streaming cluster. Subscriptions
 // will be rate matched and follow at-least delivery semantics.
 type Subscription interface {
+	Pending() (int, int, error)
 	Unsubscribe() error
 }
 
@@ -301,6 +302,11 @@ func (sub *subscription) Unsubscribe() error {
 	}
 
 	return nil
+}
+
+// Pending returns the number of queued messages and queued bytes in the client for this subscription.
+func (s *subscription) Pending() (int, int, error) {
+	return s.inboxSub.Pending()
 }
 
 // Ack manually acknowledges a message.


### PR DESCRIPTION
I wanted to get some subscription metrics available in nats that were not available in streaming such as # of pending messages, # of delivered messages, etc. I think allowing these metrics to be exposed increases programmer usability to build better systems around nats streaming.

The tests were pulled from sub_test.go