### PR TITLE
Use the connect timeout for subscriber requests

### DIFF
--- a/sub.go
+++ b/sub.go
@@ -224,7 +224,7 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 	}
 
 	b, _ := sr.Marshal()
-	reply, err := sc.nc.Request(sc.subRequests, b, 2*time.Second)
+	reply, err := sc.nc.Request(sc.subRequests, b, sc.opts.ConnectTimeout)
 	if err != nil {
 		sub.inboxSub.Unsubscribe()
 		return nil, err
@@ -287,8 +287,7 @@ func (sub *subscription) Unsubscribe() error {
 		Inbox:    sub.ackInbox,
 	}
 	b, _ := usr.Marshal()
-	// FIXME(dlc) - make timeout configurable.
-	reply, err := nc.Request(reqSubject, b, 2*time.Second)
+	reply, err := nc.Request(reqSubject, b, sc.opts.ConnectTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In some environments, when the NATS streaming server is under heavy load, two seconds may not be long enough for subscriber requests.  It seems reasonable that the connect timeout could be used in requests made by the subscriber API.  

An alternative is to offer a new subscriber option, although I don't see much value in that - we would typically recommend the same value as that used for connection requests.