### PR TITLE
updated stan-bench.go to use the -s url specified on the command line.

### DIFF
--- a/examples/stan-bench.go
+++ b/examples/stan-bench.go
@@ -106,7 +106,7 @@ func main() {
 func runPublisher(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs int, msgSize int, async bool, pubID string, maxPubAcksInflight int) {
 	nc, err := opts.Connect()
 	if err != nil {
-		log.Fatalf("Subscriber %s can't connect: %v\n", pubID, err)
+		log.Fatalf("Publisher %s can't connect: %v\n", pubID, err)
 	}
 	snc, err := stan.Connect("test-cluster", pubID, stan.MaxPubAcksInflight(maxPubAcksInflight), stan.NatsConn(nc))
 	if err != nil {

--- a/examples/stan-bench.go
+++ b/examples/stan-bench.go
@@ -152,6 +152,7 @@ func runPublisher(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs in
 
 	benchmark.AddPubSample(bench.NewSample(numMsgs, msgSize, start, time.Now(), snc.NatsConn()))
 	snc.Close()
+	nc.Close()
 	donewg.Done()
 }
 
@@ -188,5 +189,6 @@ func runSubscriber(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs i
 	<-ch
 	benchmark.AddSubSample(bench.NewSample(numMsgs, msgSize, start, time.Now(), snc.NatsConn()))
 	snc.Close()
+	nc.Close()
 	donewg.Done()
 }

--- a/examples/stan-bench.go
+++ b/examples/stan-bench.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/nats-io/go-nats-streaming"
 	"github.com/nats-io/nats"
 	"github.com/nats-io/nats/bench"
-	"strings"
+
 )
 
 // Some sane defaults
@@ -35,7 +36,7 @@ func usage() {
 var benchmark *bench.Benchmark
 
 func main() {
-	var urls = flag.String("s", nats.DefaultURL, "The NATS server URL")
+	var urls = flag.String("s", nats.DefaultURL, "The NATS server URLs (separated by comma")
 	var tls = flag.Bool("tls", false, "Use TLS secure sonnection")
 	var numPubs = flag.Int("np", DefaultNumPubs, "Number of concurrent publishers")
 	var numSubs = flag.Int("ns", DefaultNumSubs, "Number of concurrent subscribers")


### PR DESCRIPTION
Stan-bench can now use remote servers specified on the command line.

Removed the text regarding providing a comma separated list of multiple servers. I'm not sure if this is even an option with the way the rest of the test is setup.