### PR TITLE
Remove SubscriptionCloseRequest protocol

### DIFF
--- a/pb/protocol.pb.go
+++ b/pb/protocol.pb.go
@@ -18,7 +18,6 @@
 		SubscriptionRequest
 		SubscriptionResponse
 		UnsubscribeRequest
-		SubscriptionCloseRequest
 		CloseRequest
 		CloseResponse
 */
@@ -181,21 +180,6 @@ func (m *UnsubscribeRequest) Reset()         { *m = UnsubscribeRequest{} }
 func (m *UnsubscribeRequest) String() string { return proto.CompactTextString(m) }
 func (*UnsubscribeRequest) ProtoMessage()    {}
 
-// Protocol for a client to close a subscription without unsubscribing.
-// For non-durables, this would be equivalent to UnsubscribeRequest,
-// however, for durables, this allow the server to remove the subscriber
-// but keep the durable interest.
-// Will return a SubscriptionResponse
-type SubscriptionCloseRequest struct {
-	ClientID string `protobuf:"bytes,1,opt,name=clientID,proto3" json:"clientID,omitempty"`
-	Subject  string `protobuf:"bytes,2,opt,name=subject,proto3" json:"subject,omitempty"`
-	Inbox    string `protobuf:"bytes,3,opt,name=inbox,proto3" json:"inbox,omitempty"`
-}
-
-func (m *SubscriptionCloseRequest) Reset()         { *m = SubscriptionCloseRequest{} }
-func (m *SubscriptionCloseRequest) String() string { return proto.CompactTextString(m) }
-func (*SubscriptionCloseRequest) ProtoMessage()    {}
-
 // Protocol for a client to close a connection
 type CloseRequest struct {
 	ClientID string `protobuf:"bytes,1,opt,name=clientID,proto3" json:"clientID,omitempty"`
@@ -224,7 +208,6 @@ func init() {
 	proto.RegisterType((*SubscriptionRequest)(nil), "pb.SubscriptionRequest")
 	proto.RegisterType((*SubscriptionResponse)(nil), "pb.SubscriptionResponse")
 	proto.RegisterType((*UnsubscribeRequest)(nil), "pb.UnsubscribeRequest")
-	proto.RegisterType((*SubscriptionCloseRequest)(nil), "pb.SubscriptionCloseRequest")
 	proto.RegisterType((*CloseRequest)(nil), "pb.CloseRequest")
 	proto.RegisterType((*CloseResponse)(nil), "pb.CloseResponse")
 	proto.RegisterEnum("pb.StartPosition", StartPosition_name, StartPosition_value)
@@ -646,42 +629,6 @@ func (m *UnsubscribeRequest) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
-func (m *SubscriptionCloseRequest) Marshal() (data []byte, err error) {
-	size := m.Size()
-	data = make([]byte, size)
-	n, err := m.MarshalTo(data)
-	if err != nil {
-		return nil, err
-	}
-	return data[:n], nil
-}
-
-func (m *SubscriptionCloseRequest) MarshalTo(data []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	if len(m.ClientID) > 0 {
-		data[i] = 0xa
-		i++
-		i = encodeVarintProtocol(data, i, uint64(len(m.ClientID)))
-		i += copy(data[i:], m.ClientID)
-	}
-	if len(m.Subject) > 0 {
-		data[i] = 0x12
-		i++
-		i = encodeVarintProtocol(data, i, uint64(len(m.Subject)))
-		i += copy(data[i:], m.Subject)
-	}
-	if len(m.Inbox) > 0 {
-		data[i] = 0x1a
-		i++
-		i = encodeVarintProtocol(data, i, uint64(len(m.Inbox)))
-		i += copy(data[i:], m.Inbox)
-	}
-	return i, nil
-}
-
 func (m *CloseRequest) Marshal() (data []byte, err error) {
 	size := m.Size()
 	data = make([]byte, size)
@@ -969,24 +916,6 @@ func (m *UnsubscribeRequest) Size() (n int) {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
 	l = len(m.DurableName)
-	if l > 0 {
-		n += 1 + l + sovProtocol(uint64(l))
-	}
-	return n
-}
-
-func (m *SubscriptionCloseRequest) Size() (n int) {
-	var l int
-	_ = l
-	l = len(m.ClientID)
-	if l > 0 {
-		n += 1 + l + sovProtocol(uint64(l))
-	}
-	l = len(m.Subject)
-	if l > 0 {
-		n += 1 + l + sovProtocol(uint64(l))
-	}
-	l = len(m.Inbox)
 	if l > 0 {
 		n += 1 + l + sovProtocol(uint64(l))
 	}
@@ -2579,143 +2508,6 @@ func (m *UnsubscribeRequest) Unmarshal(data []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.DurableName = string(data[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipProtocol(data[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthProtocol
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *SubscriptionCloseRequest) Unmarshal(data []byte) error {
-	l := len(data)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowProtocol
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := data[iNdEx]
-			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: SubscriptionCloseRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SubscriptionCloseRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ClientID", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProtocol
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthProtocol
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.ClientID = string(data[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Subject", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProtocol
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthProtocol
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Subject = string(data[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Inbox", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowProtocol
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthProtocol
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Inbox = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pb/protocol.proto
+++ b/pb/protocol.proto
@@ -104,17 +104,6 @@ message UnsubscribeRequest {
   string durableName = 4; // Optional durable name which survives client restarts
 }
 
-// Protocol for a client to close a subscription without unsubscribing.
-// For non-durables, this would be equivalent to UnsubscribeRequest,
-// however, for durables, this allow the server to remove the subscriber
-// but keep the durable interest.
-// Will return a SubscriptionResponse
-message SubscriptionCloseRequest {
-  string clientID    = 1; // ClientID
-  string subject     = 2; // Subject for the subscription
-  string inbox       = 3; // Inbox subject to identify the subscription
-}
-
 // Protocol for a client to close a connection
 message CloseRequest {
   string clientID = 1;  // Client name provided to Connect() requests

--- a/sub.go
+++ b/sub.go
@@ -256,10 +256,6 @@ func (sc *conn) subscribe(subject, qgroup string, cb MsgHandler, options ...Subs
 	return sub, nil
 }
 
-type marshaller interface {
-	Marshal() ([]byte, error)
-}
-
 // closeOrUnsubscribe performs either close or unsubsribe based on
 // given boolean.
 func (sub *subscription) closeOrUnsubscribe(doClose bool) error {
@@ -303,23 +299,12 @@ func (sub *subscription) closeOrUnsubscribe(doClose bool) error {
 	nc := sc.nc
 	sc.Unlock()
 
-	var req marshaller
-	if doClose {
-		scr := &pb.SubscriptionCloseRequest{
-			ClientID: sc.clientID,
-			Subject:  sub.subject,
-			Inbox:    sub.ackInbox,
-		}
-		req = scr
-	} else {
-		usr := &pb.UnsubscribeRequest{
-			ClientID: sc.clientID,
-			Subject:  sub.subject,
-			Inbox:    sub.ackInbox,
-		}
-		req = usr
+	usr := &pb.UnsubscribeRequest{
+		ClientID: sc.clientID,
+		Subject:  sub.subject,
+		Inbox:    sub.ackInbox,
 	}
-	b, _ := req.Marshal()
+	b, _ := usr.Marshal()
 	reply, err := nc.Request(reqSubject, b, sc.opts.ConnectTimeout)
 	if err != nil {
 		if err == nats.ErrTimeout {


### PR DESCRIPTION
This is related to PR #115 and server side [PR 203](https://github.com/nats-io/nats-streaming-server/pull/203).
I noticed that we could have used `UnsubscribeRequest` since content
of that one and `SubscriptionCloseRequest` were same for relevant fields.
Also, the server was actually implemented with `UnsubscribeRequest`
and works fine. What matters is the subject the protocol is sent to.