### PR TITLE
Fix TestTimeoutOnRequests test

### DIFF
--- a/stan_test.go
+++ b/stan_test.go
@@ -1882,7 +1882,13 @@ func TestNatsURLOption(t *testing.T) {
 }
 
 func TestTimeoutOnRequests(t *testing.T) {
-	s := RunServer(clusterName)
+	ns := natsd.RunDefaultServer()
+	defer ns.Shutdown()
+
+	opts := server.GetDefaultOptions()
+	opts.ID = clusterName
+	opts.NATSServerURL = nats.DefaultURL
+	s := server.RunServerWithOpts(opts, nil)
 	defer s.Shutdown()
 
 	sc := NewDefaultConnection(t)


### PR DESCRIPTION
Use a standalone NATS Server for this test so that we check
that requests timeout due to NATS Streaming server being shutdown
and don't get broken pipe from NATS Server not running.