### PR TITLE
Propagate STAN clientID to Nats Conn for better debugging

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -181,7 +181,7 @@ func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	c.nc = c.opts.NatsConn
 	// Create a NATS connection if it doesn't exist.
 	if c.nc == nil {
-		nc, err := nats.Connect(c.opts.NatsURL)
+		nc, err := nats.Connect(c.opts.NatsURL, nats.Name(clientID))
 		if err != nil {
 			return nil, err
 		}

--- a/stan_test.go
+++ b/stan_test.go
@@ -1976,6 +1976,20 @@ func TestSubscriberClose(t *testing.T) {
 	closeSubscriber(t, "durqueuesub", "queue")
 }
 
+func TestOptionNatsName(t *testing.T) {
+	s := RunServer(clusterName)
+	defer s.Shutdown()
+	sc := NewDefaultConnection(t)
+	defer sc.Close()
+
+	// Make sure we can get the STAN-created Conn.
+	nc := sc.NatsConn()
+
+	if n := nc.Opts.Name; n != clientName {
+		t.Fatalf("Unexpected nats client name: %s", n)
+	}
+}
+
 func closeSubscriber(t *testing.T, channel, subType string) {
 	sc := NewDefaultConnection(t)
 	defer sc.Close()


### PR DESCRIPTION
Related: https://github.com/nats-io/go-nats-streaming/issues/33

Currently the connection name for a STAN server viewed from the nats connection page are always empty. Making it difficult to debug connections.
This PR propagates STAN clientID down to the NATS connection, and should fix this issue.