### PR TITLE
[DOC] The requirements for client ID [ci skip]

### DIFF
--- a/stan.go
+++ b/stan.go
@@ -169,6 +169,7 @@ type ack struct {
 }
 
 // Connect will form a connection to the NATS Streaming subsystem.
+// Note that clientID can contain only alphanumeric and `-` or `_` characters.
 func Connect(stanClusterID, clientID string, options ...Option) (Conn, error) {
 	// Process Options
 	c := conn{clientID: clientID, opts: DefaultOptions}


### PR DESCRIPTION
There is also a change in the server to return a more specific
error should a client provide an invalid client ID. It will make
it clear for the user why the connect fails.
(Server PR: https://github.com/nats-io/nats-streaming-server/pull/306)

Resolves #133