### PR TITLE
[FIXED] stan-bench usage [ci skip]

### DIFF
--- a/examples/stan-bench/main.go
+++ b/examples/stan-bench/main.go
@@ -40,7 +40,7 @@ const (
 )
 
 func usage() {
-	log.Fatalf("Usage: stan-bench [-s server (%s)] [--tls] [-id CLIENT_ID] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-csv csvfile] [-mpa MAX_NUMBER_OF_PUBLISHED_ACKS_INFLIGHT] [-io] [-a] <subject>\n", nats.DefaultURL)
+	log.Fatalf("Usage: stan-bench [-s server (%s)] [-tls] [-c CLUSTER_ID] [-id CLIENT_ID] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-csv csvfile] [-mpa MAX_NUMBER_OF_PUBLISHED_ACKS_INFLIGHT] [-io] [-a] <subject>\n", nats.DefaultURL)
 }
 
 var benchmark *bench.Benchmark


### PR DESCRIPTION
The cluster ID option was missing from usage

Resolves #198

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>