### PR TITLE
Replace megacheck with staticcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-- 1.9.x
 - 1.10.x
 - 1.11.x
 install:
@@ -9,13 +8,13 @@ install:
 - go get github.com/nats-io/nats-streaming-server
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
-- go get -u honnef.co/go/tools/cmd/megacheck
+- go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
 - $(exit $(go fmt ./... | wc -l))
 - go vet ./...
 - misspell -error -locale US .
-- megacheck ./...
+- staticcheck ./...
 script:
 - go test -i -race ./...
 - go test -v -race ./...

--- a/stan.go
+++ b/stan.go
@@ -188,7 +188,7 @@ func Pings(interval, maxOut int) Option {
 		// do not check values.
 		if !testAllowMillisecInPings {
 			if interval < 1 || maxOut <= 2 {
-				return fmt.Errorf("Invalid ping values: interval=%v (min>0) maxOut=%v (min=2)", interval, maxOut)
+				return fmt.Errorf("invalid ping values: interval=%v (min>0) maxOut=%v (min=2)", interval, maxOut)
 			}
 		}
 		o.PingIterval = interval
@@ -586,7 +586,7 @@ func (sc *conn) processAck(m *nats.Msg) {
 	pa := &pb.PubAck{}
 	err := pa.Unmarshal(m.Data)
 	if err != nil {
-		panic(fmt.Errorf("Error during ack unmarshal: %v", err))
+		panic(fmt.Errorf("error during ack unmarshal: %v", err))
 	}
 
 	// Remove
@@ -722,7 +722,7 @@ func (sc *conn) processMsg(raw *nats.Msg) {
 	msg := &Msg{}
 	err := msg.Unmarshal(raw.Data)
 	if err != nil {
-		panic(fmt.Errorf("Error processing unmarshal for msg: %v", err))
+		panic(fmt.Errorf("error processing unmarshal for msg: %v", err))
 	}
 	// Lookup the subscription
 	sc.RLock()


### PR DESCRIPTION
Fixed errors reported by staticcheck.
Removed Go 1.9 from build matrix since staticcheck does not work
on that release and Go 1.9 is no longer supported by Golang.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>